### PR TITLE
Use CommandsService namespace for Commands service

### DIFF
--- a/CommandsService/Program.cs
+++ b/CommandsService/Program.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace PlatformService
+namespace CommandsService
 {
     public class Program
     {

--- a/CommandsService/Startup.cs
+++ b/CommandsService/Startup.cs
@@ -16,7 +16,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using static System.Runtime.InteropServices.JavaScript.JSType;
 
-namespace PlatformService
+namespace CommandsService
 {
     public class Startup
     {


### PR DESCRIPTION
## Summary
- rename namespaces to `CommandsService` in Program and Startup classes

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68960c0f8cac8325849830e751ea6691