### PR TITLE
Fix service .http files

### DIFF
--- a/CommandsService/CommandsService.http
+++ b/CommandsService/CommandsService.http
@@ -1,6 +1,7 @@
 @CommandsService_HostAddress = http://localhost:5066
 
-GET {{CommandsService_HostAddress}}/weatherforecast/
+### Test inbound connection
+POST {{CommandsService_HostAddress}}/api/c/platforms
 Accept: application/json
 
 ###

--- a/PlatformService/PlatformService.http
+++ b/PlatformService/PlatformService.http
@@ -1,6 +1,22 @@
 @PlatformService_HostAddress = http://localhost:5028
+@id = 1
 
-GET {{PlatformService_HostAddress}}/weatherforecast/
+### Get all platforms
+GET {{PlatformService_HostAddress}}/api/platforms
 Accept: application/json
+
+### Get platform by ID
+GET {{PlatformService_HostAddress}}/api/platforms/{{id}}
+Accept: application/json
+
+### Create a new platform
+POST {{PlatformService_HostAddress}}/api/platforms
+Content-Type: application/json
+
+{
+  "name": "CommandLine",
+  "publisher": "CLI",
+  "cost": "Free"
+}
 
 ###


### PR DESCRIPTION
## Summary
- update PlatformService.http with platform endpoints
- update CommandsService.http to test CommandsService endpoint

## Testing
- `dotnet test` *(fails: .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689645e118588325bf479a26e7749266