### PR TITLE
Add unit and integration tests for PlatformService

### DIFF
--- a/src/PlatformService/tests/PlatformService.IntegrationTests/PlatformServiceApiFactory.cs
+++ b/src/PlatformService/tests/PlatformService.IntegrationTests/PlatformServiceApiFactory.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using PlatformService.Infrastructure.Data;
+using PlatformService.Api;
+using PlatformService.Application.Contracts.Services;
+using PlatformService.Application.Dtos;
+using PlatformService.Domain.Entities;
+
+namespace PlatformService.IntegrationTests;
+
+/// <summary>
+/// Custom <see cref="WebApplicationFactory{TEntryPoint}"/> for integration tests.
+/// It swaps the real database for an in-memory provider and replaces external
+/// service clients with fakes so tests run deterministically.
+/// </summary>
+public class PlatformServiceApiFactory : WebApplicationFactory<Program>
+{
+    /// <summary>
+    /// Configures the test host with in-memory storage and seeded data.
+    /// </summary>
+    /// <param name="builder">The web host builder used for the test server.</param>
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<PlatformDbContext>));
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+
+            var databaseName = Guid.NewGuid().ToString();
+            services.AddDbContext<PlatformDbContext>(options =>
+                options.UseInMemoryDatabase(databaseName));
+
+            var cmdDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ICommandDataClient));
+            if (cmdDescriptor != null)
+            {
+                services.Remove(cmdDescriptor);
+            }
+            // Replace outbound HTTP communication with a fake client.
+            services.AddSingleton<ICommandDataClient, FakeCommandDataClient>();
+
+            var busDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IMessageBusClient));
+            if (busDescriptor != null)
+            {
+                services.Remove(busDescriptor);
+            }
+            // Replace the message bus with a fake implementation.
+            services.AddSingleton<IMessageBusClient, FakeMessageBusClient>();
+
+            var sp = services.BuildServiceProvider();
+            using var scope = sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+            db.Database.EnsureCreated();
+            db.Platforms.AddRange(
+                new Platform { Name = "Seed1", Publisher = "Pub1", Cost = "Free" },
+                new Platform { Name = "Seed2", Publisher = "Pub2", Cost = "Free" },
+                new Platform { Name = "Seed3", Publisher = "Pub3", Cost = "Free" }
+            );
+            db.SaveChanges();
+        });
+    }
+
+    /// <summary>
+    /// Minimal ICommandDataClient stub used during tests to avoid real HTTP calls.
+    /// </summary>
+    private class FakeCommandDataClient : ICommandDataClient
+    {
+        public Task SendPlatformToCommand(PlatformReadDto platform) => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Minimal IMessageBusClient stub used during tests to avoid real message bus traffic.
+    /// </summary>
+    private class FakeMessageBusClient : IMessageBusClient
+    {
+        public Task PublishNewPlatform(PlatformPublishedDto platformPublishedDto) => Task.CompletedTask;
+    }
+}

--- a/src/PlatformService/tests/PlatformService.IntegrationTests/PlatformsControllerTests.cs
+++ b/src/PlatformService/tests/PlatformService.IntegrationTests/PlatformsControllerTests.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using System.Net.Http.Json;
+using PlatformService.Application.Dtos;
+using Xunit;
+
+namespace PlatformService.IntegrationTests;
+
+/// <summary>
+/// Integration tests for the PlatformsController using the custom API factory.
+/// </summary>
+public class PlatformsControllerTests : IClassFixture<PlatformServiceApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public PlatformsControllerTests(PlatformServiceApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetPlatforms_ReturnsSeededPlatforms()
+    {
+        var response = await _client.GetAsync("/api/platforms");
+        response.EnsureSuccessStatusCode();
+        var platforms = await response.Content.ReadFromJsonAsync<List<PlatformReadDto>>();
+        Assert.NotNull(platforms);
+    }
+
+    [Fact]
+    public async Task CreatePlatform_PersistsPlatform()
+    {
+        var before = await _client.GetFromJsonAsync<List<PlatformReadDto>>("/api/platforms") ?? new();
+        var createDto = new PlatformCreateDto { Name = "Test", Publisher = "Tester", Cost = "Free" };
+        var response = await _client.PostAsJsonAsync("/api/platforms", createDto);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var after = await _client.GetFromJsonAsync<List<PlatformReadDto>>("/api/platforms") ?? new();
+        Assert.Equal(before.Count + 1, after.Count);
+    }
+}

--- a/src/PlatformService/tests/PlatformService.UnitTests/PlatformServiceTests.cs
+++ b/src/PlatformService/tests/PlatformService.UnitTests/PlatformServiceTests.cs
@@ -1,0 +1,90 @@
+using AutoMapper;
+using Moq;
+using PlatformService.Application.AppServices.Interfaces;
+using PlatformService.Application.Dtos;
+using PlatformService.Application.Services;
+using PlatformService.Domain.Entities;
+using PlatformService.Application.Contracts.Repos;
+using PlatformService.Application.Contracts.Services;
+using Xunit;
+
+namespace PlatformService.UnitTests;
+
+public class PlatformServiceTests
+{
+    private readonly Mock<IPlatformRepo> _repo = new();
+    private readonly Mock<IMapper> _mapper = new();
+    private readonly Mock<ICommandDataClient> _commandClient = new();
+    private readonly Mock<IMessageBusClient> _messageBus = new();
+
+    private Application.Services.PlatformService CreateService()
+        => new(_repo.Object, _mapper.Object, _commandClient.Object, _messageBus.Object);
+
+    [Fact]
+    public void GetAllPlatforms_ReturnsMappedDtos()
+    {
+        var platforms = new List<Platform>
+        {
+            new() { Id = 1, Name = "P1", Publisher = "Pub1", Cost = "Free" },
+            new() { Id = 2, Name = "P2", Publisher = "Pub2", Cost = "Free" }
+        };
+        var readDtos = new List<PlatformReadDto>
+        {
+            new() { Id = 1, Name = "P1", Publisher = "Pub1", Cost = "Free" },
+            new() { Id = 2, Name = "P2", Publisher = "Pub2", Cost = "Free" }
+        };
+
+        _repo.Setup(r => r.GetAllPlatforms()).Returns(platforms);
+        _mapper.Setup(m => m.Map<IEnumerable<PlatformReadDto>>(platforms)).Returns(readDtos);
+
+        var service = CreateService();
+        var result = service.GetAllPlatforms().ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("P1", result[0].Name);
+    }
+
+    [Fact]
+    public void GetPlatformById_Existing_ReturnsDto()
+    {
+        var platform = new Platform { Id = 7, Name = "Test", Publisher = "Pub", Cost = "Free" };
+        var readDto = new PlatformReadDto { Id = 7, Name = "Test", Publisher = "Pub", Cost = "Free" };
+
+        _repo.Setup(r => r.GetPlatformById(7)).Returns(platform);
+        _mapper.Setup(m => m.Map<PlatformReadDto>(platform)).Returns(readDto);
+
+        var service = CreateService();
+        var result = service.GetPlatformById(7);
+
+        Assert.NotNull(result);
+        Assert.Equal(readDto.Name, result!.Name);
+    }
+
+    [Fact]
+    public async Task CreatePlatformAsync_ValidInput_PersistsAndPublishes()
+    {
+        var createDto = new PlatformCreateDto { Name = "New", Publisher = "Me", Cost = "Free" };
+        var platform = new Platform { Id = 10, Name = "New", Publisher = "Me", Cost = "Free" };
+        var readDto = new PlatformReadDto { Id = 10, Name = "New", Publisher = "Me", Cost = "Free" };
+        var publishedDto = new PlatformPublishedDto { Id = 10, Name = "New", Event = "Platform_Published" };
+
+        _mapper.Setup(m => m.Map<Platform>(createDto)).Returns(platform);
+        _mapper.Setup(m => m.Map<PlatformReadDto>(platform)).Returns(readDto);
+        _mapper.Setup(m => m.Map<PlatformPublishedDto>(readDto)).Returns(publishedDto);
+        _repo.Setup(r => r.CreatePlatform(platform));
+        _repo.Setup(r => r.SaveChanges()).Returns(true);
+        _commandClient.Setup(c => c.SendPlatformToCommand(readDto)).Returns(Task.CompletedTask);
+        _messageBus.Setup(m => m.PublishNewPlatform(It.Is<PlatformPublishedDto>(p => p.Id == 10))).Returns(Task.CompletedTask);
+
+        var service = CreateService();
+        var result = await service.CreatePlatformAsync(createDto);
+
+        Assert.NotNull(result);
+        Assert.Equal(readDto.Id, result!.Id);
+        _repo.Verify(r => r.CreatePlatform(platform), Times.Once);
+        _repo.Verify(r => r.SaveChanges(), Times.Once);
+        _commandClient.Verify(c => c.SendPlatformToCommand(readDto), Times.Once);
+        _messageBus.Verify(m => m.PublishNewPlatform(It.Is<PlatformPublishedDto>(p => p.Id == 10 && p.Event == "Platform_Published")), Times.Once);
+    }
+}
+

--- a/src/PlatformService/tests/README.md
+++ b/src/PlatformService/tests/README.md
@@ -1,0 +1,19 @@
+# PlatformService Tests
+
+This folder contains the unit and integration tests for the PlatformService.
+
+## Projects
+
+- `PlatformService.UnitTests` – verifies application and repository logic by isolating dependencies with mocks and an in-memory database.
+- `PlatformService.IntegrationTests` – spins up the full API using a custom `WebApplicationFactory` that swaps external services for fakes and seeds an in-memory database.
+
+## Running tests
+
+Run all tests for the service from the solution file:
+
+```bash
+dotnet test PlatformService.sln
+```
+
+The command executes both unit and integration tests.
+


### PR DESCRIPTION
## Summary
- add PlatformService application service unit tests
- add custom test host and controller integration tests
- document test infrastructure and add README for PlatformService tests

## Testing
- `~/dotnet/dotnet test src/PlatformService/PlatformService.sln`


------
https://chatgpt.com/codex/tasks/task_e_689b78cc4a6c8325b4097b6f0d3dfc67