### PR TITLE
docs: agregar documentación en español

### DIFF
--- a/src/CommandService/README.md
+++ b/src/CommandService/README.md
@@ -1,0 +1,37 @@
+# CommandService
+
+Servicio que recibe datos de plataformas y gestiona comandos asociados.
+
+## Proyectos
+- **CommandService.Api**: API REST.
+- **CommandService.Application**: lógica de negocio.
+- **CommandService.Domain**: entidades.
+- **CommandService.Infrastructure**: EF Core, suscriptor de RabbitMQ y cliente gRPC.
+
+## Comunicación
+- Consume eventos de RabbitMQ emitidos por PlatformService.
+- Obtiene la lista de plataformas desde PlatformService mediante gRPC.
+
+## Endpoints REST
+- `GET /api/c/platforms`
+- `POST /api/c/platforms` (prueba de conectividad)
+- `GET /api/c/platforms/{platformId}/commands`
+- `GET /api/c/platforms/{platformId}/commands/{commandId}`
+- `POST /api/c/platforms/{platformId}/commands`
+
+## Requisitos
+- .NET 9 SDK
+- RabbitMQ disponible en `localhost:5672`
+
+El servicio usa una base de datos en memoria.
+
+## Ejecución
+```bash
+dotnet run --project src/CommandService/CommandService.Api
+```
+El servicio escucha en `http://localhost:5066`.
+
+## Prueba rápida
+```bash
+curl http://localhost:5066/api/c/platforms
+```

--- a/src/PlatformService/README.md
+++ b/src/PlatformService/README.md
@@ -1,0 +1,36 @@
+# PlatformService
+
+Servicio encargado de gestionar las plataformas de software. Expone una API REST para crear y consultar plataformas y publica eventos cuando se agregan nuevas.
+
+## Proyectos
+- **PlatformService.Api**: API REST y servicio gRPC.
+- **PlatformService.Application**: lógica de negocio y mapeos.
+- **PlatformService.Domain**: entidades del dominio.
+- **PlatformService.Infrastructure**: EF Core, clientes HTTP y RabbitMQ.
+
+## Endpoints principales
+- `GET /api/platforms`
+- `GET /api/platforms/{id}`
+- `POST /api/platforms`
+
+Al crear una plataforma:
+- Se envía una petición HTTP a CommandService.
+- Se publica un evento `PlatformPublished` en RabbitMQ.
+- El servicio gRPC `GrpcPlatform` permite a otros servicios consultar la lista de plataformas.
+
+## Requisitos
+- .NET 9 SDK
+- RabbitMQ disponible en `localhost:5672`
+
+En desarrollo utiliza una base de datos en memoria; en producción requiere una conexión SQL Server llamada `PlatformService`.
+
+## Ejecución
+```bash
+dotnet run --project src/PlatformService/PlatformService.Api
+```
+El servicio escucha en `http://localhost:5028`.
+
+## Prueba rápida
+```bash
+curl http://localhost:5028/api/platforms
+```


### PR DESCRIPTION
## Summary
- reescribir README principal con arquitectura, tecnologías y pasos de prueba
- añadir documentación específica para PlatformService y CommandService
- resaltar aprendizajes personales en README principal

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8f5ff81c8325922f860073fedcd7